### PR TITLE
Update provision-aws.md

### DIFF
--- a/integrated-mgmt-workshop/provision-aws.md
+++ b/integrated-mgmt-workshop/provision-aws.md
@@ -29,7 +29,7 @@ $ sudo dnf install vim git python3 expect
 $ python3 -m pip install --user --upgrade pip setuptools
 $ python3 -m pip install --user wheel
 $ python3 -m pip install --user ansible==2.10.5
-$ python3 -m pip install --user requests
+$ python3 -m pip install --user requests==2.26.0
 $ python3 -m pip install --user yamllint==1.19.0
 $ python3 -m pip install --user boto3==1.16.59
 $ python3 -m pip install --user boto==2.49.0


### PR DESCRIPTION
Stock RHEL 8 fails dependencies when following these instructions because it installs python3-requests version 2.20.0 which is incompatible with that version of urllib3. Adding this version gets it to download a more up to date version of requests that cleans up  the dependency problems I was having